### PR TITLE
Create WebTools starter workflow

### DIFF
--- a/workflow-templates/web-tools.properties.json
+++ b/workflow-templates/web-tools.properties.json
@@ -1,0 +1,5 @@
+{
+  "name": "WebTools Workflow",
+  "description": "WebTools workflow template",
+  "iconName": "umbrella-solid"
+}

--- a/workflow-templates/web-tools.yaml
+++ b/workflow-templates/web-tools.yaml
@@ -1,0 +1,9 @@
+name: Web Tools
+on:
+  workflow-dispatch
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Starting workflow..."


### PR DESCRIPTION
Since we can't manually run a workflow from a branch unless it exists in `main`, this sets up a very basic stub that can get merged first.  Then the feature work can be developed and tested on a branch.